### PR TITLE
Added ability to specify 'failed' as the queue name

### DIFF
--- a/check_resque
+++ b/check_resque
@@ -30,7 +30,7 @@ else
   redis = Redis.new(:host => options[:host])
   Resque.redis = redis
   values = options[:queues].split(",").inject({}) do |memo, queue|
-    memo[queue] = Resque.size(queue)
+    memo[queue] = queue == 'failed' ? Resque::Failure.count : Resque.size(queue)
     memo
   end
 


### PR DESCRIPTION
This will include/measure the count of the failed jobs in the output
